### PR TITLE
Allow reading password from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ login: person@example.com
 
 You can also override these values on the command line with `jira --user person --login person@example.com`.  The `login` value will be used only for authentication purposes, the `user` value will be used when a user name is required for any Jira service API calls.
 
-#### keyring password source
+#### `keyring` password source
 On OSX and Linux there are a few keyring providers that `go-jira` can use (via this [golang module](https://github.com/tmc/keyring)).  To integrate `go-jira` with a supported keyring just add this configuration to `$HOME/.jira.d/config.yml`:
 ```yaml
 password-source: keyring
@@ -352,4 +352,12 @@ if [ -n "${GPG_AGENT_INFO}" ]; then
     fi
 fi
 export GPG_TTY=$(tty)
+```
+
+#### `stdin` password source
+
+When `password-source` is set to `stdin`, the `jira login` command will read from stdin until EOF, and the bytes read will be the used as the password. This is useful if you have some other programmatic method for fetching passwords. For example, if `password-generator` creates a one-time password and prints it to stdout, you could use it like this.
+
+```bash
+$ ./password-generator | jira login --endpoint=https://my.jira.endpoint.com --user=USERNAME
 ```

--- a/jiracli/password.go
+++ b/jiracli/password.go
@@ -3,6 +3,7 @@ package jiracli
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -57,6 +58,12 @@ func (o *GlobalOptions) GetPass() string {
 					passwd = strings.TrimSpace(buf.String())
 				}
 			}
+		} else if o.PasswordSource.Value == "stdin" {
+			allBytes, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				panic(fmt.Sprintf("unable to read bytes from stdin: %s", err))
+			}
+			passwd = string(allBytes)
 		} else {
 			log.Warningf("Unknown password-source: %s", o.PasswordSource)
 		}


### PR DESCRIPTION
Allow reading password from stdin in `jira login`. This is useful for
combining the jira tool with other command-line utilities. Fixes https://github.com/go-jira/go-jira/issues/262