### PR TITLE
Fix worklog template for multiline comments

### DIFF
--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -547,7 +547,7 @@ transition:
 const defaultWorklogTemplate = `{{/* worklog template */ -}}
 # issue: {{ .issue }}
 comment: |~
-  {{ or .comment "" }}
+  {{ or .comment "" | indent 2 }}
 timeSpent: {{ or .timeSpent "" }}
 started: {{ or .started "" }}
 `


### PR DESCRIPTION
Worklog entries like
```
$ jira worklog add -m"multiline                                     
test" MyIssue -T1m
```
would produce broken YAML in the current version. This small template change fixes it.